### PR TITLE
add underscore dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "central": "./bin/central.js"
   },
   "dependencies": {
+    "underscore":"^1.8.2",
     "backbone": "^1.1.2",
     "backbone-super-sync": "0.0.22",
     "cheerio": "^0.18.0",


### PR DESCRIPTION
Hi @himmelarthur !

I just tried to install my first central app, and I ran into this error:
![capture d ecran 2015-04-01 a 23 20 25](https://cloud.githubusercontent.com/assets/1640952/6952856/bf5eaa1c-d8c5-11e4-8465-35982eb1c7cd.png)

I think that underscore is a dependency not only to backbone, but to central too.

Cheers !
